### PR TITLE
getName() => getDisplayName()

### DIFF
--- a/src/main/java/net/vectromc/vbasic/commands/staff/TeleportCommands.java
+++ b/src/main/java/net/vectromc/vbasic/commands/staff/TeleportCommands.java
@@ -42,10 +42,10 @@ public class TeleportCommands implements CommandExecutor {
                             nitrogen.setPlayerColor(target);
                             nitrogen.setPlayerColor(player);
                             player.teleport(target);
-                            Utils.sendMessage(player, plugin.getConfig().getString("TeleportedToPlayer").replaceAll("%target%", target.getDisplayName()));
+                            Utils.sendMessage(player, plugin.getConfig().getString("TeleportedToPlayer").replaceAll("%target%", target.getName()));
                             for (Player onlineStaff : Bukkit.getOnlinePlayers()) {
                                 if (plugin.toggle_staff_alerts.contains(onlineStaff.getUniqueId())) {
-                                    onlineStaff.sendMessage(ChatColor.translateAlternateColorCodes('&', plugin.getConfig().getString("StaffAlerts.TeleportToPlayer").replaceAll("%player%", player.getDisplayName()).replaceAll("%target%", target.getDisplayName())));
+                                    onlineStaff.sendMessage(ChatColor.translateAlternateColorCodes('&', plugin.getConfig().getString("StaffAlerts.TeleportToPlayer").replaceAll("%player%", player.getName()).replaceAll("%target%", target.getName())));
                                 }
                             }
                         } else {
@@ -63,11 +63,11 @@ public class TeleportCommands implements CommandExecutor {
                                 nitrogen.setPlayerColor(target2);
                                 nitrogen.setPlayerColor(player);
                                 target.teleport(target2);
-                                Utils.sendMessage(player, plugin.getConfig().getString("YouTeleportedPlayerToPlayer").replaceAll("%target1%", target.getDisplayName()).replaceAll("%target2%", target2.getDisplayName()));
-                                Utils.sendTargetMessage(target, plugin.getConfig().getString("PlayerTeleportedPlayerToPlayer").replaceAll("%target%", target.getDisplayName()).replaceAll("%player%", player.getDisplayName()));
+                                Utils.sendMessage(player, plugin.getConfig().getString("YouTeleportedPlayerToPlayer").replaceAll("%target1%", target.getName()).replaceAll("%target2%", target2.getName()));
+                                Utils.sendTargetMessage(target, plugin.getConfig().getString("PlayerTeleportedPlayerToPlayer").replaceAll("%target%", target.getName()).replaceAll("%player%", player.getName()));
                                 for (Player onlineStaff : Bukkit.getOnlinePlayers()) {
                                     if (plugin.toggle_staff_alerts.contains(onlineStaff.getUniqueId())) {
-                                        onlineStaff.sendMessage(ChatColor.translateAlternateColorCodes('&', plugin.getConfig().getString("StaffAlerts.PlayerTeleportedPlayerToPlayer").replaceAll("%player%", player.getDisplayName()).replaceAll("%target1%", target.getDisplayName()).replaceAll("%target2%", target2.getDisplayName())));
+                                        onlineStaff.sendMessage(ChatColor.translateAlternateColorCodes('&', plugin.getConfig().getString("StaffAlerts.PlayerTeleportedPlayerToPlayer").replaceAll("%player%", player.getName()).replaceAll("%target1%", target.getName()).replaceAll("%target2%", target2.getName())));
                                     }
                                 }
                             } else {

--- a/src/main/java/net/vectromc/vnitrogen/listeners/StaffWorldChangeEvents.java
+++ b/src/main/java/net/vectromc/vnitrogen/listeners/StaffWorldChangeEvents.java
@@ -25,7 +25,7 @@ public class StaffWorldChangeEvents implements Listener {
             plugin.setPlayerColor(player);
             for (Player onlineStaff : Bukkit.getOnlinePlayers()) {
                 if (onlineStaff.hasPermission(plugin.getConfig().getString("StaffWorldChange.notifypermission"))) {
-                    onlineStaff.sendMessage(ChatColor.translateAlternateColorCodes('&', plugin.getConfig().getString("StaffWorldChange.format").replaceAll("%player%", player.getDisplayName()).replaceAll("%oldWorld%", oldWorld)).replaceAll("%newWorld%", newWorld));
+                    onlineStaff.sendMessage(ChatColor.translateAlternateColorCodes('&', plugin.getConfig().getString("StaffWorldChange.format").replaceAll("%player%", player.getName()).replaceAll("%oldWorld%", oldWorld)).replaceAll("%newWorld%", newWorld));
                 }
             }
         }

--- a/src/main/java/net/vectromc/vnitrogen/listeners/StaffWorldChangeEvents.java
+++ b/src/main/java/net/vectromc/vnitrogen/listeners/StaffWorldChangeEvents.java
@@ -25,7 +25,7 @@ public class StaffWorldChangeEvents implements Listener {
             plugin.setPlayerColor(player);
             for (Player onlineStaff : Bukkit.getOnlinePlayers()) {
                 if (onlineStaff.hasPermission(plugin.getConfig().getString("StaffWorldChange.notifypermission"))) {
-                    onlineStaff.sendMessage(ChatColor.translateAlternateColorCodes('&', plugin.getConfig().getString("StaffWorldChange.format").replaceAll("%player%", player.getName()).replaceAll("%oldWorld%", oldWorld)).replaceAll("%newWorld%", newWorld));
+                    onlineStaff.sendMessage(ChatColor.translateAlternateColorCodes('&', plugin.getConfig().getString("StaffWorldChange.format").replaceAll("%player%", player.getDisplayName()).replaceAll("%oldWorld%", oldWorld)).replaceAll("%newWorld%", newWorld));
                 }
             }
         }


### PR DESCRIPTION
in almost every instance of a chat message where there was a player#getDisplayName() method, you changed it to player#getName(). This isn't correct and its not how the plugin is supposed to be, the reason it gets the display name is so that it can format the player's rank prefix / rank color in that message. The player's displayname is supposed to be according to their rank, so thats why its there in the first place.

// Merge back from my original branch.